### PR TITLE
Do not try to include nil object in lstat response

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -432,7 +432,11 @@ RCT_EXPORT_METHOD(lstat:(NSString *)path callback:(RCTResponseSenderBlock) callb
     if(isDir == YES) {
         for(NSString * p in files) {
             NSString * filePath = [NSString stringWithFormat:@"%@/%@", path, p];
-            [res addObject:[RNFetchBlobFS stat:filePath error:&error]];
+            NSDictionary * fileStats = [RNFetchBlobFS stat:filePath error:&error];
+            if (fileStats == nil) {
+                continue;
+            }
+            [res addObject:fileStats];
         }
     }
     else {

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -433,10 +433,9 @@ RCT_EXPORT_METHOD(lstat:(NSString *)path callback:(RCTResponseSenderBlock) callb
         for(NSString * p in files) {
             NSString * filePath = [NSString stringWithFormat:@"%@/%@", path, p];
             NSDictionary * fileStats = [RNFetchBlobFS stat:filePath error:&error];
-            if (fileStats == nil) {
-                continue;
+            if (fileStats != nil) {
+                [res addObject:fileStats];
             }
-            [res addObject:fileStats];
         }
     }
     else {


### PR DESCRIPTION
`[RNFetchBlobFS stat:]` is able return `nil` and that's not a valid value in the return array of `lstat` which [seem to cause crashes for users](https://console.firebase.google.com/u/0/project/relive-1483378336491/crashlytics/app/ios:cc.relive.reliveapp/issues/255a9c6b6557b400b4ecf4faff0ac177?time=1599782400000:1600991999000&sessionEventKey=392be8193cc94734b77faf6c6013310d_1454632440045257254). To fix this issue, check for `nil` values and don't include them in the response. 