### PR TITLE
Add option to stat method to log details on null returns

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -255,8 +255,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void stat(String path, Callback callback) {
-        RNFetchBlobFS.stat(path, callback);
+    public void stat(String path, boolean verboseNull, Callback callback) {
+        RNFetchBlobFS.stat(path, verboseNull, callback);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -803,11 +803,6 @@ class RNFetchBlobFS {
             try {
                 path = normalizePath(path);
                 WritableMap result = statFileVerboseNull(path);
-
-                if (!!verboseNull) {
-                    throw new Exception("Jasper did something wrong");
-                }
-
                 callback.invoke(null, result);
             } catch(Exception err) {
                 callback.invoke("failed to stat path `" + path + "` because error `" + err.getLocalizedMessage() + "`", null);

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -1046,13 +1046,9 @@ class RNFetchBlobFS {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             args.putString("internal_free", String.valueOf(stat.getFreeBytes()));
             args.putString("internal_total", String.valueOf(stat.getTotalBytes()));
-            try {
-                StatFs statEx = new StatFs(Environment.getExternalStorageDirectory().getPath());
-                args.putString("external_free", String.valueOf(statEx.getFreeBytes()));
-                args.putString("external_total", String.valueOf(statEx.getTotalBytes()));
-            } catch(IllegalArgumentException err) {
-                // Do nothing
-            }
+            StatFs statEx = new StatFs(Environment.getExternalStorageDirectory().getPath());
+            args.putString("external_free", String.valueOf(statEx.getFreeBytes()));
+            args.putString("external_total", String.valueOf(statEx.getTotalBytes()));
 
         }
         callback.invoke(null ,args);

--- a/fs.js
+++ b/fs.js
@@ -213,12 +213,12 @@ function appendFile(path: string, data: string | Array<number>, encoding?: strin
  * @param  {string} path Target path
  * @return {RNFetchBlobFile}
  */
-function stat(path: string): Promise<RNFetchBlobFile> {
+function stat(path: string, verboseNull: boolean): Promise<RNFetchBlobFile> {
   return new Promise((resolve, reject) => {
     if (typeof path !== 'string') {
       return reject(addCode('EINVAL', new TypeError('Missing argument "path" ')))
     }
-    RNFetchBlob.stat(path, (err, stat) => {
+    RNFetchBlob.stat(path, verboseNull, (err, stat) => {
       if (err)
         reject(new Error(err))
       else {
@@ -365,7 +365,7 @@ function slice(src: string, dest: string, start: number, end: number): Promise {
   }
 
   if (start < 0 || end < 0 || !start || !end) {
-    p = p.then(() => stat(src))
+    p = p.then(() => stat(src, false))
       .then((stat) => {
         size = Math.floor(stat.size)
         start = normalize(start || 0, size)

--- a/index.d.ts
+++ b/index.d.ts
@@ -378,7 +378,7 @@ export interface FS {
      * Show statistic data of a path.
      * @param  path Target path
      */
-    stat(path: string): Promise<RNFetchBlobStat>;
+    stat(path: string, verboseNull: boolean): Promise<RNFetchBlobStat>;
 
     lstat(path: string): Promise<RNFetchBlobStat[]>;
 

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function fetchFile(options = {}, method, url, headers = {}, body):Promise {
 
     // read data from file system
     default:
-      promise = fs.stat(url)
+      promise = fs.stat(url, false)
       .then((stat) => {
         total = stat.size
         return fs.readStream(url,

--- a/index.js.flow
+++ b/index.js.flow
@@ -48,7 +48,7 @@ declare class FsApi {
   scanFile(pairs: {mime: string, path: string}[]): Promise<void>;
   session(name: string): RNFetchBlobSession;
   slice(src: string, dest: string, start: number, end: number): Promise<string>;
-  stat(path: string): Promise<RNFetchBlobStat>;
+  stat(path: string, verboseNull: boolean): Promise<RNFetchBlobStat>;
   unlink(path: string): Promise<void>;
   writeFile(path: string, data: string | number[], encoding?: Encoding | "uri"): Promise<number>;
   writeStream(path: string, encoding: Encoding, append?: boolean): Promise<RNFetchBlobWriteStream>;

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -372,7 +372,7 @@ RCT_EXPORT_METHOD(ls:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve r
 }
 
 #pragma mark - fs.stat
-RCT_EXPORT_METHOD(stat:(NSString *)target callback:(RCTResponseSenderBlock) callback)
+RCT_EXPORT_METHOD(stat:(NSString *)target verboseNull:(Boolean)verboseNull callback:(RCTResponseSenderBlock) callback)
 {
 
     [RNFetchBlobFS getPathFromUri:target completionHandler:^(NSString *path, ALAssetRepresentation *asset) {

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -372,7 +372,7 @@ RCT_EXPORT_METHOD(ls:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve r
 }
 
 #pragma mark - fs.stat
-RCT_EXPORT_METHOD(stat:(NSString *)target verboseNull:(Boolean)verboseNull callback:(RCTResponseSenderBlock) callback)
+RCT_EXPORT_METHOD(stat:(NSString *)target verboseNull:(BOOL)verboseNull callback:(RCTResponseSenderBlock) callback)
 {
 
     [RNFetchBlobFS getPathFromUri:target completionHandler:^(NSString *path, ALAssetRepresentation *asset) {

--- a/polyfill/Blob.js
+++ b/polyfill/Blob.js
@@ -137,7 +137,7 @@ export default class Blob extends EventTarget {
       if(defer)
         return
       else {
-        p = fs.stat(orgPath)
+        p = fs.stat(orgPath, false)
               .then((stat) =>  {
                 return Promise.resolve(stat.size)
               })


### PR DESCRIPTION
## What type of PR is this? (Check all if applicable)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor

## Description
`null` returns of `.stat()` might include suppressed exceptions by `statFile()`. This PR adds an option to `.stat()` method to make null returns more verbose by rejecting promise. 